### PR TITLE
Fix file format identifier for input files in setup instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -57,7 +57,7 @@ Create `chr1-star-index.yaml`:
 InputFiles:
   - class: File
     location: rnaseq/reference_data/chr1.fa
-    format: http://edamontology.org/format_1930
+    format: http://edamontology.org/format_1929
 IndexName: 'hg19-chr1-STAR-index'
 Gtf:
   class: File
@@ -155,7 +155,7 @@ Create `chr1-star-index.yaml`:
 InputFiles:
   - class: File
     location: keep:9178fe1b80a08a422dbe02adfd439764+925/reference_data/chr1.fa
-    format: http://edamontology.org/format_1930
+    format: http://edamontology.org/format_1929
 IndexName: 'hg19-chr1-STAR-index'
 Gtf:
   class: File


### PR DESCRIPTION
The instructions ask the learner to create a file "chr1-star-index.yaml" that references an input file in the FASTA format, if they are to follow the steps for generating the STAR index themselves.

In the YAML file however, the "format" field for that file referred to something else (FASTQ format).  If the user followed the instructions and submitted the workflow to Arvados, the run would fail validation.

Fixed by using the intended URI for the format (tested in Arvados 2.8.0 dev).

Arvados-DCO-1.1-Signed-off-by: Zoë Ma <zoe.ma@curii.com>

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
